### PR TITLE
fix: make cortex installer plugin enablement idempotent

### DIFF
--- a/cortex/installer.py
+++ b/cortex/installer.py
@@ -13,12 +13,15 @@ Usage (CLI):
 
 from __future__ import annotations
 
+import os
 import shutil
 import sys
 from dataclasses import dataclass, field
 from importlib import resources
 from pathlib import Path
 from typing import Callable, Optional
+
+import yaml
 
 # ---- Default install targets ------------------------------------------------
 
@@ -30,6 +33,32 @@ DEFAULT_CHROMA_PATH = Path.home() / ".hermes" / "cortex" / "chroma"
 DEFAULT_HERMES_MEMORY = Path.home() / ".hermes" / "memories" / "MEMORY.md"
 DEFAULT_HERMES_USER = Path.home() / ".hermes" / "memories" / "USER.md"
 DEFAULT_HERMES_SOUL = Path.home() / ".hermes" / "SOUL.md"
+
+
+def _hermes_home() -> Path:
+    """Return the Hermes home for the current process/profile."""
+    try:
+        from hermes_constants import get_hermes_home  # type: ignore
+
+        return Path(get_hermes_home()).expanduser()
+    except Exception:
+        return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")).expanduser()
+
+
+def _unique_strings(values: object) -> list[str]:
+    """Normalize a YAML scalar/list to a de-duplicated list of strings."""
+    if not isinstance(values, list):
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        item = value.strip()
+        if item and item not in seen:
+            out.append(item)
+            seen.add(item)
+    return out
 
 VAULT_FOLDERS = [
     "00_inbox",
@@ -261,76 +290,67 @@ class Installer:
         soul.write_text(updated, encoding="utf-8")
 
     def _enable_cortex_toolset(self) -> None:
-        """Ensure cortex plugin and toolset are enabled in Hermes config.yaml."""
+        """Ensure cortex plugin and CLI toolset are enabled exactly once."""
         config = self.plan.config_path
         if not config:
             return
 
-        # The Hermes config.yaml is at ~/.hermes/config.yaml, not the cortex config
-        hermes_config = Path.home() / ".hermes" / "config.yaml"
+        hermes_config = _hermes_home() / "config.yaml"
         if not hermes_config.exists():
             self._action(f"SKIP cortex toolset: Hermes config not found: {hermes_config}")
             return
 
-        original = hermes_config.read_text(encoding="utf-8")
-        changes = []
+        raw_config = yaml.safe_load(hermes_config.read_text(encoding="utf-8")) or {}
+        if not isinstance(raw_config, dict):
+            self._action(f"SKIP cortex toolset: Hermes config is not a YAML mapping: {hermes_config}")
+            return
 
-        # Enable plugin
-        if "plugins:" in original:
-            if "- cortex" not in original.split("plugins:")[1].split("\n")[0:10]:
-                # Add cortex to enabled plugins list
-                updated = original.replace(
-                    "  enabled:\n",
-                    "  enabled:\n  - cortex\n",
-                    1
-                )
-                if updated != original:
-                    changes.append("cortex plugin enabled")
-                    original = updated
-            else:
-                changes.append("cortex plugin already enabled")
-        else:
-            updated = original + "\nplugins:\n  enabled:\n    - cortex\n  disabled: []\n"
-            changes.append("cortex plugin section added")
-            original = updated
+        changes: list[str] = []
 
-        # Enable toolset for CLI
-        if "platform_toolsets:" in original:
-            cli_section = original.split("platform_toolsets:")[1]
-            if "cli:" in cli_section:
-                cli_part = cli_section.split("cli:")[1].split("\n")[0]
-                if "cortex" not in cli_part.split("\n")[0]:
-                    # Add cortex after hermes-cli in cli tools
-                    updated = original.replace(
-                        "    - hermes-cli",
-                        "    - hermes-cli\n    - cortex",
-                        1
-                    )
-                    if updated != original:
-                        changes.append("cortex toolset enabled for CLI")
-                        original = updated
-                    else:
-                        changes.append("cortex CLI toolset already present")
-                else:
-                    changes.append("cortex CLI toolset already enabled")
-            else:
-                updated = original.replace(
-                    "platform_toolsets:",
-                    "platform_toolsets:\n  cli:\n    - cortex",
-                    1
-                )
-                if updated != original:
-                    changes.append("cortex CLI toolset added")
-                    original = updated
-        else:
-            updated = original + "\nplatform_toolsets:\n  cli:\n    - cortex\n"
-            changes.append("cortex toolset section added")
-            original = updated
+        plugins = raw_config.setdefault("plugins", {})
+        if not isinstance(plugins, dict):
+            plugins = {}
+            raw_config["plugins"] = plugins
+            changes.append("plugins section repaired")
+
+        original_enabled = plugins.get("enabled")
+        enabled = _unique_strings(original_enabled)
+        if "cortex" not in enabled:
+            enabled.append("cortex")
+            changes.append("cortex plugin enabled")
+        elif isinstance(original_enabled, list) and len(enabled) != len(original_enabled):
+            changes.append("cortex plugin entries deduplicated")
+        plugins["enabled"] = enabled
+
+        original_disabled = plugins.get("disabled")
+        disabled = [item for item in _unique_strings(original_disabled) if item != "cortex"]
+        if isinstance(original_disabled, list) and len(disabled) != len(_unique_strings(original_disabled)):
+            changes.append("cortex removed from disabled plugins")
+        plugins["disabled"] = disabled
+
+        platform_toolsets = raw_config.setdefault("platform_toolsets", {})
+        if not isinstance(platform_toolsets, dict):
+            platform_toolsets = {}
+            raw_config["platform_toolsets"] = platform_toolsets
+            changes.append("platform_toolsets section repaired")
+
+        original_cli_toolsets = platform_toolsets.get("cli")
+        cli_toolsets = _unique_strings(original_cli_toolsets)
+        if "cortex" not in cli_toolsets:
+            cli_toolsets.append("cortex")
+            changes.append("cortex toolset enabled for CLI")
+        elif isinstance(original_cli_toolsets, list) and len(cli_toolsets) != len(original_cli_toolsets):
+            changes.append("cortex CLI toolset entries deduplicated")
+        platform_toolsets["cli"] = cli_toolsets
 
         if changes:
             self._action(f"Update Hermes config: {', '.join(changes)}")
             if not self.plan.dry_run:
-                hermes_config.write_text(original, encoding="utf-8")
+                hermes_config.parent.mkdir(parents=True, exist_ok=True)
+                hermes_config.write_text(
+                    yaml.safe_dump(raw_config, sort_keys=False, allow_unicode=True),
+                    encoding="utf-8",
+                )
         else:
             self._action("Hermes config already has cortex enabled")
 

--- a/skills/long-term-memory/vault-infrastructure/SKILL.md
+++ b/skills/long-term-memory/vault-infrastructure/SKILL.md
@@ -1,26 +1,36 @@
 ---
 name: vault-infrastructure
-description: Infrastructure for the hermes-cortex vault — folder structure, note types, templates, and promotion rules. Used when bootstrapping or repairing the long-term memory system.
+description: "Use when bootstrapping, auditing, or repairing a Cortex/Obsidian vault: folder layout, note types, frontmatter, naming, promotion rules, seed hygiene, and post-write maintenance."
 ---
 
 # Vault Infrastructure
 
-## Three layers
+## Purpose
 
-- **Vault** = curated long-term memory (Obsidian notes)
-- **Sessions** = raw conversation transcripts
-- **Git repo** = versioned code and templates
+Use this skill for the **curated Vault layer** of Cortex memory: how notes are
+organized, how durable knowledge is promoted, and how vault changes are verified.
 
-Do **not** put raw sessions into the vault. Do **not** put curated knowledge only in git.
+This skill is intentionally not a deployment or incident-debugging guide. Put
+rare diagnostics in `memory-diagnostics` or a reference file instead of polluting
+this hotpath.
+
+## Layers
+
+- **Vault** — curated long-term memory: stable facts, decisions, project context,
+  runbooks, maps, and people notes.
+- **Sessions** — raw conversation history and temporary evidence. Do not copy raw
+  transcripts into the Vault.
+- **Runtime state** — Cortex config, chunks, embeddings, and generated graph data.
+  Keep this separate from curated notes.
 
 ## Vault structure
 
-```
+```text
 00_inbox/       Review-only candidates that need human judgment
 10_facts/       Stable facts about systems, tools, environment
 20_decisions/   Decisions with rationale
 30_projects/    Active project contexts
-40_runbooks/    Repeatable procedures, troubleshooting
+40_runbooks/    Repeatable procedures and troubleshooting
 50_people/      People notes
 60_maps/        Index and navigation notes
 80_templates/   Note templates
@@ -28,7 +38,8 @@ Do **not** put raw sessions into the vault. Do **not** put curated knowledge onl
 
 ## Note types and frontmatter
 
-Every note needs YAML frontmatter. Use the canonical enum tables in `docs/METADATA.md`; do not invent local status values. Cortex indexes notes with these fields:
+Every curated note needs YAML frontmatter. Use the canonical enum tables in
+`docs/METADATA.md`; do not invent local status values.
 
 ```yaml
 ---
@@ -42,92 +53,91 @@ last_verified: YYYY-MM-DD
 ---
 ```
 
-Folder-to-type mapping: `10_facts/`=fact, `20_decisions/`=decision, `30_projects/`=project, `40_runbooks/`=runbook, `60_maps/`=map, `50_people/`=person.
+Folder-to-type mapping:
+
+| Folder | Type |
+|---|---|
+| `10_facts/` | `fact` |
+| `20_decisions/` | `decision` |
+| `30_projects/` | `project` |
+| `40_runbooks/` | `runbook` |
+| `50_people/` | `person` |
+| `60_maps/` | `map` |
 
 ## Naming convention
 
-`<Type> - <Title>.md` example: `Decision - Use Obsidian as long-term memory.md`
+Use readable, stable note names:
 
-No special characters besides hyphens and spaces. Shell-friendly folder names (underscores), readable note titles (spaces).
+```text
+<Type> - <Title>.md
+```
+
+Examples:
+
+- `Fact - Matrix Gateway Home Room.md`
+- `Decision - Use Obsidian as long-term memory.md`
+- `Runbook - Rebuild Cortex index.md`
+
+Avoid special characters beyond spaces and hyphens. Keep titles descriptive
+enough to identify the note without opening it.
 
 ## Promotion rules
 
-When processing session knowledge, decide where to put it:
+Promote information into the Vault only when it is durable and useful later.
 
-- **→ Vault** if the item is: durable, reusable, a fact/decision/runbook/project update worth finding later
-- **→ Git repo** if: setup docs, scripts, templates, reference material
-- **→ Leave in sessions only** if: temporary, speculative, discarded, noisy chat
+| Source item | Target |
+|---|---|
+| Stable system/tool/environment fact | `10_facts/` |
+| Decision with rationale or tradeoffs | `20_decisions/` |
+| Active project context or roadmap | `30_projects/` |
+| Repeatable procedure or troubleshooting workflow | `40_runbooks/` |
+| Person preference/profile detail suitable for curated notes | `50_people/` |
+| Navigation/index material | `60_maps/` |
+| Uncertain candidate needing review | `00_inbox/` |
+| Temporary task status, raw chat, stale IDs, speculative notes | leave in sessions |
 
-## Templates
+Prefer updating an existing matching note over creating a near-duplicate.
 
-Maintain these templates in the vault's `80_templates/`: `fact-note.md`, `decision-note.md`, `project-note.md`, `runbook-note.md`.
+## Templates and seed notes
 
-## Bootstrap
+Maintain canonical templates in `80_templates/`:
 
-When setting up a new vault, seed public-safe starter notes only. Example shape:
-- `60_maps/Map - Knowledge Index.md`
-- `30_projects/Project - Example System.md`
-- `20_decisions/Decision - Use a curated vault for long-term memory.md`
+- `fact-note.md`
+- `decision-note.md`
+- `project-note.md`
+- `runbook-note.md`
 
-Do not put personal machine names, delivery targets, private scheduler state, or
-real account identifiers into tracked seed notes or examples.
+Seed notes must be public-safe and generic. Do not include real account IDs,
+private delivery targets, machine-specific secrets, or operator-only automation
+state in shipped seed notes.
 
-## Cortex runtime layout and lifecycle
+## Post-write maintenance
 
-Keep these concerns separate:
+After creating or editing curated Vault notes:
 
-- `~/.hermes/plugins/cortex/` = plugin code/runtime Git checkout. Update with `git pull --ff-only` (and the install/sync step if the repo requires it). Do not store user config, Chroma data, chunks, or other mutable state here.
-- `~/.hermes/cortex/` = profile-local Cortex config and runtime state (`config.yaml`, chunks, embeddings/vector store, graph artifacts). This location is acceptable because it keeps mutable state out of the plugin repo, but expose it clearly in UX/docs (`hermes cortex status`, `config path/show/edit`) so it does not feel hidden.
-- `<workspace>/hermes-cortex/` = development checkout.
+1. Validate frontmatter when the workflow provides a validator.
+2. Run `hermes cortex index` (or `cortex index` in standalone workflows).
+3. Run `hermes cortex embed` (or `cortex embed`).
+4. Re-run graph/lifecycle maintenance when links, aliases, or maps changed.
+5. Verify the updated note is discoverable with `vault_search` or the Cortex CLI.
 
-Current workflows should use `hermes cortex ...`; remove stale deployment-path instructions instead of preserving legacy compatibility.
+`cortex index` and `cortex embed` read the vault path from the active Cortex
+config; they do not take a vault path argument.
 
-There are two live lifecycle mechanisms to keep distinct when auditing Cortex:
+## Common pitfalls
 
-1. **Nightly promotion cron** — promotes/maintains durable knowledge on a schedule.
-2. **Post-vault-write maintenance** — after Jarvis changes vault notes, run `hermes cortex lifecycle maintenance` (or the equivalent index/embed/graph sequence) and verify.
+- Do not confuse raw sessions with curated knowledge.
+- Do not create duplicate notes when an existing note can be updated.
+- Do not invent frontmatter status values; use the canonical metadata enums.
+- Do not store generated index, embedding, graph, cache, or runtime config files
+  inside the curated Vault notes tree.
+- Do not put operator-specific private data into shipped templates or seed notes.
 
-## Nightly Promotion (Cronjob)
+## Verification checklist
 
-Cortex can package a scheduled Hermes job that promotes durable session knowledge
-into the vault. Treat this as an example lifecycle pattern, not evidence of any
-specific operator's scheduler. Tracked docs must not include real job IDs,
-delivery channels, account names, or private notification targets.
-
-The promotion pattern is canonical-first:
-
-- clear, high-confidence facts/decisions/projects/runbooks are written directly
-  to `10_facts/`, `20_decisions/`, `30_projects/`, or `40_runbooks/`
-- uncertain or duplicate-sensitive items go to `00_inbox/` only when human review
-  is needed
-- active `00_inbox/` candidates need `status: draft`, `review_status: pending`,
-  and `review_reason`
-- archived source notes must not keep `promote: true`
-
-After writing, a scheduled job should run lifecycle maintenance (index,
-embeddings, graph) and deliver any summary through operator-local/private config.
-For scheduler validation, prefer the scheduler/home context because arbitrary
-worker profiles may show a different cron store:
-
-```bash
-env -u HERMES_HOME HOME=/path/to/scheduler-home hermes cron list
-env -u HERMES_HOME HOME=/path/to/scheduler-home hermes cortex cron status
-```
-
-**Session sources:** Prefer the active Hermes session database when available.
-If a maintenance prompt or legacy workflow reads session log files directly, make
-that source explicit and keep channel-specific names generic, e.g. JSONL logs,
-JSON session logs, and ignored API request dumps.
-
-## Pitfalls
-
-- Do not confuse raw session history with curated knowledge
-- Do not keep the vault only in templates; create real notes too
-- Do not let legacy vault paths survive a cutover
-- Do not run `install.sh` as root
-- **When asked to audit, fix, or geradeziehen the cortex setup:** code changes come first, documentation is the follow-up. Never produce only docs while leaving the actual project code untouched.
-- **Nightly promotion cron:** Keep scheduler prompts public-safe. Do not document real job IDs, delivery targets, or private channel names in tracked repo docs.
-- **Session sources:** Prefer the active Hermes session database. If reading logs directly, describe sources generically and verify that both JSONL and JSON session formats are covered when relevant.
-- For systematic cortex health checks, see `references/cortex-health-check.md`.
-- For config-path and hook-debugging deep-dive (search order, timing traps, log verification), see `references/cortex-config-debugging.md`.
-- For setup and CLI workflow, see the repo `README.md` and `docs/CLI.md`.
+- [ ] Note is in the correct folder for its `type`.
+- [ ] Frontmatter is present and uses canonical enum values.
+- [ ] Existing notes were checked before creating a new one.
+- [ ] Public/shared seed content contains no private operator details.
+- [ ] Index and embeddings were refreshed after Vault writes.
+- [ ] Important notes are linked from a relevant map when discoverability matters.

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -45,6 +45,24 @@ class FakePrompt(Prompt):
 
 # ---- Plan execution --------------------------------------------------------
 
+@pytest.fixture(autouse=True)
+def isolated_hermes_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Prevent installer tests from touching the operator's real Hermes config."""
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        """
+plugins:
+  enabled: []
+  disabled: []
+platform_toolsets:
+  cli: []
+""".lstrip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    return hermes_home
+
 
 @pytest.fixture
 def plan(tmp_path: Path) -> InstallPlan:
@@ -162,6 +180,50 @@ def test_default_install_plan_does_not_imply_markdown_mutation() -> None:
     plan = InstallPlan()
     assert plan.update_hermes_memory is False
     assert plan.update_hermes_soul_memory_rules is False
+
+
+def test_enable_cortex_toolset_is_idempotent_and_deduplicates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    hermes_config = hermes_home / "config.yaml"
+    hermes_config.write_text(
+        """
+plugins:
+  enabled:
+  - other-plugin
+  - cortex
+  - cortex
+  disabled:
+  - cortex
+  - disabled-plugin
+platform_toolsets:
+  cli:
+  - terminal
+  - cortex
+  - cortex
+""".lstrip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    plan = InstallPlan(
+        vault_path=tmp_path / "vault",
+        config_path=tmp_path / "cortex" / "config.yaml",
+        chunks_path=tmp_path / "chunks.jsonl",
+        chroma_path=tmp_path / "chroma",
+        overwrite_policy="force",
+    )
+
+    Installer(plan, prompt=FakePrompt([])).run()
+    Installer(plan, prompt=FakePrompt([])).run()
+
+    raw = yaml.safe_load(hermes_config.read_text(encoding="utf-8"))
+    assert raw["plugins"]["enabled"] == ["other-plugin", "cortex"]
+    assert raw["plugins"]["disabled"] == ["disabled-plugin"]
+    assert raw["platform_toolsets"]["cli"] == ["terminal", "cortex"]
 
 
 def test_run_with_hermes_memory_paths(tmp_path: Path) -> None:


### PR DESCRIPTION
Deduplicate cortex plugin/toolset entries when running init and isolate installer tests from the operator's live Hermes config. Also trims the bundled vault-infrastructure skill back to official vault guidance.